### PR TITLE
UIcleanmaptools

### DIFF
--- a/BlackberryMap/server.R
+++ b/BlackberryMap/server.R
@@ -73,7 +73,7 @@ server <- function(input, output) {
                                      singleFeature = T,
                                      polylineOptions = F,
                                      circleOptions = F,
-                                     #circleMarkerOptions = F,
+                                     markerOptions = F,
                                      rectangleOptions = F,
                                      editOptions  = editToolbarOptions()) %>% 
       hideGroup(c("Satellite")) %>% 


### PR DESCRIPTION
1. Removed extraneous leaflet map editing buttons.
2. Added code to buffer small square (1m2) around circle markers so users can add tiny patches to the map easily.